### PR TITLE
prepend command builtin to sed

### DIFF
--- a/complete_alias
+++ b/complete_alias
@@ -311,7 +311,7 @@ _expand_alias() {
         local cmd="${COMP_WORDS[$beg]}"
 
         ##  get alias body;
-        local str0="$( alias "$cmd" | sed -E 's/[^=]*=//' | xargs )"
+        local str0="$( alias "$cmd" | command sed -E 's/[^=]*=//' | xargs )"
 
         ##  split alias body into words;
         _split_cmd_line "$str0"


### PR DESCRIPTION
Uses command builtin to sed so user defined aliases and functions aren't ran - actual binary is