### PR TITLE
Enable 'inheritance' of completion rules from other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,36 @@ to config `complete-alias`, set these envars *before* sourcing the main script:
         ...
         complete -F _complete_alias "${!BASH_ALIASES[@]}"
 
+-   how to complete my alias with the completion rules of *another command*?
+
+    Define configuration function `_complete_alias_overrides` *after* all
+    aliases have been defined and completed:
+
+        _complete_alias_overrides() {
+            echo alias_name command_to_inherit_completion_from
+        }
+
+    for example, to complete alias `g` aliased to
+    `source /path/to/custom-wrapper-script.sh` with the completion rules of
+    command `git`:
+
+    1.   define the alias as you would normally do:
+
+        alias g="source /path/to/custom-wrapper-script.sh"
+
+    2.    complete the alias:
+
+        complete -F _complete_alias g
+
+    3.    Specify the command to inherit the completion rules from by
+          defining the configuration function:
+
+        _complete_alias_overrides() {
+            echo g git
+        }
+
+    then alias `g` will inherit the completion rules of the command `git`.
+
 -   `sudo` completion is not working correctly?
 
     there is a known case with `sudo` that can go wrong; for example:

--- a/complete_alias
+++ b/complete_alias
@@ -517,6 +517,18 @@ __compal__expand_alias() {
         local str0; str0="$(alias "$cmd")"
         str0="$(echo "${str0#*=}" | command xargs)"
 
+        ##  override alias body using config function _complete_alias_overrides;
+        ##  we need this if we want to use the completion rules of another
+        ##  one-word command instead of the completion rules of the command
+        ##  embedded in the original alias body
+        if type _complete_alias_overrides &> /dev/null; then
+            while IFS= read -r pair; do
+                if [[ $(echo "$pair" | cut -d" " -f1 | grep -w "$cmd") ]]; then
+                    str0="$(echo "$pair" | cut -d" " -f2)"
+                fi
+            done < <(_complete_alias_overrides)
+        fi
+
         ##  split alias body into words;
         __compal__split_cmd_line "$str0"
         local words0=( "${__compal__retval[@]}" )


### PR DESCRIPTION
Override alias body using new config function `_complete_alias_overrides`. This comes in handy if we want to use the completion rules of another one-word command instead of the completion rules of the command embedded in the original alias body

I put a small example in the README file, and I'm currently using something like this in my dotfiles [to complete a custom wrapper script with the completion rules of `git`](https://github.com/lu0/dotfiles_linuxMint/commit/aeb9c869891e4a9dbf5a2cb87d43b64e9cb3c04f)